### PR TITLE
Add OpenCL integration for LBM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 # Find required packages
 find_package(OpenCL REQUIRED)
+add_definitions(-DHAVE_OPENCL)
 
 # Find optional packages
 find_package(PkgConfig)
@@ -64,6 +65,7 @@ set(COMMON_SOURCES
   src/terrain_manager.cpp
   src/boundary_conditions.cpp
   src/visualization.cpp
+  src/opencl_weather.cpp
 )
 
 # Header files
@@ -75,6 +77,7 @@ set(HEADERS
   include/boundary_conditions.hpp
   include/visualization.hpp
   include/common.hpp
+  include/opencl_weather.hpp
 )
 
 # Main executable
@@ -108,11 +111,15 @@ target_link_libraries(tornado_sim ${OpenCL_LIBRARIES} Threads::Threads)
 add_executable(weather_forecast src/forecast_main.cpp ${COMMON_SOURCES})
 target_link_libraries(weather_forecast ${OpenCL_LIBRARIES} Threads::Threads)
 
+# OpenCL accelerated weather simulation example
+add_executable(opencl_sim src/opencl_main.cpp ${COMMON_SOURCES})
+target_link_libraries(opencl_sim ${OpenCL_LIBRARIES} Threads::Threads)
+
 # Copy OpenCL kernels to build directory
 file(COPY ${CMAKE_SOURCE_DIR}/kernels/ DESTINATION ${CMAKE_BINARY_DIR}/kernels/)
 
 # Installation
-install(TARGETS atmospheric_lbm tornado_sim weather_forecast
+install(TARGETS atmospheric_lbm tornado_sim weather_forecast opencl_sim
         RUNTIME DESTINATION bin)
 
 install(DIRECTORY kernels/ DESTINATION share/atmospheric_lbm/kernels/)

--- a/benchmarks/benchmark_lbm.cpp
+++ b/benchmarks/benchmark_lbm.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 int main() {
-    AtmosphericLBM lbm;
+    AtmosphericLBM lbm(false);
     auto start = std::chrono::high_resolution_clock::now();
     lbm.run();
     auto end = std::chrono::high_resolution_clock::now();

--- a/include/atmospheric_lbm.hpp
+++ b/include/atmospheric_lbm.hpp
@@ -1,9 +1,21 @@
 #ifndef ATMOSPHERIC_LBM_HPP
 #define ATMOSPHERIC_LBM_HPP
 
+#ifdef HAVE_OPENCL
+#include "opencl_weather.hpp"
+#endif
+#include <memory>
+
 class AtmosphericLBM {
 public:
+    explicit AtmosphericLBM(bool use_opencl = false);
     void run();
+
+private:
+    bool use_opencl_;
+#ifdef HAVE_OPENCL
+    std::unique_ptr<OpenCLWeatherSim> cl_sim_;
+#endif
 };
 
 #endif

--- a/include/opencl_weather.hpp
+++ b/include/opencl_weather.hpp
@@ -1,0 +1,43 @@
+#ifndef OPENCL_WEATHER_HPP
+#define OPENCL_WEATHER_HPP
+
+#include <CL/cl.h>
+#include <vector>
+#include <string>
+
+struct Grid3D {
+    size_t nx, ny, nz;
+};
+
+class OpenCLWeatherSim {
+public:
+    OpenCLWeatherSim(const Grid3D& grid);
+    bool initialize();
+    void step();
+    const std::vector<float>& temperature() const { return h_temperature; }
+    const std::vector<float>& pressure() const { return h_pressure; }
+
+private:
+    bool init_opencl();
+    bool build_kernels(const std::string& source);
+    void upload();
+    void download();
+
+    Grid3D grid;
+    size_t cell_count;
+
+    cl_platform_id platform = nullptr;
+    cl_device_id device = nullptr;
+    cl_context context = nullptr;
+    cl_command_queue queue = nullptr;
+    cl_program program = nullptr;
+    cl_kernel update_kernel = nullptr;
+
+    cl_mem d_temperature = nullptr;
+    cl_mem d_pressure = nullptr;
+
+    std::vector<float> h_temperature;
+    std::vector<float> h_pressure;
+};
+
+#endif // OPENCL_WEATHER_HPP

--- a/kernels/weather_kernels.cl
+++ b/kernels/weather_kernels.cl
@@ -1,0 +1,16 @@
+__kernel void update_fields(__global float* temperature,
+                            __global float* pressure,
+                            int nx, int ny, int nz) {
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+    int z = get_global_id(2);
+    int idx = x + y*nx + z*nx*ny;
+    if (x >= nx || y >= ny || z >= nz) return;
+
+    float t = temperature[idx];
+    float p = pressure[idx];
+
+    float dt = 0.1f;
+    temperature[idx] = t + 0.01f * (p - 100000.0f) * dt;
+    pressure[idx] = p - 0.02f * (t - 290.0f) * dt;
+}

--- a/src/atmospheric_lbm.cpp
+++ b/src/atmospheric_lbm.cpp
@@ -1,6 +1,31 @@
 #include "atmospheric_lbm.hpp"
 #include <iostream>
 
+AtmosphericLBM::AtmosphericLBM(bool use_opencl)
+    : use_opencl_(use_opencl)
+{
+#ifdef HAVE_OPENCL
+    if (use_opencl_) {
+        Grid3D grid{32, 32, 16};
+        cl_sim_ = std::make_unique<OpenCLWeatherSim>(grid);
+        if (!cl_sim_->initialize()) {
+            std::cerr << "Failed to initialize OpenCL weather sim, falling back to CPU" << std::endl;
+            cl_sim_.reset();
+            use_opencl_ = false;
+        }
+    }
+#endif
+}
+
 void AtmosphericLBM::run() {
+#ifdef HAVE_OPENCL
+    if (use_opencl_ && cl_sim_) {
+        for (int i = 0; i < 10; ++i) {
+            cl_sim_->step();
+        }
+        std::cout << "OpenCL temperature[0]: " << cl_sim_->temperature()[0] << std::endl;
+        return;
+    }
+#endif
     std::cout << "Running LBM core..." << std::endl;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 
 int main() {
-    AtmosphericLBM lbm;
+    AtmosphericLBM lbm(false);
     lbm.run();
     std::cout << "Atmospheric LBM simulation executed." << std::endl;
     return 0;

--- a/src/opencl_main.cpp
+++ b/src/opencl_main.cpp
@@ -1,6 +1,8 @@
 #include "atmospheric_lbm.hpp"
+#include <iostream>
+
 int main() {
-    AtmosphericLBM lbm(false);
+    AtmosphericLBM lbm(true);
     lbm.run();
     return 0;
 }

--- a/src/opencl_weather.cpp
+++ b/src/opencl_weather.cpp
@@ -1,0 +1,79 @@
+#include "opencl_weather.hpp"
+#include <iostream>
+#include <fstream>
+
+OpenCLWeatherSim::OpenCLWeatherSim(const Grid3D& g) : grid(g) {
+    cell_count = grid.nx * grid.ny * grid.nz;
+    h_temperature.resize(cell_count, 290.0f);
+    h_pressure.resize(cell_count, 100000.0f);
+}
+
+bool OpenCLWeatherSim::initialize() {
+    if (!init_opencl()) return false;
+
+    d_temperature = clCreateBuffer(context, CL_MEM_READ_WRITE,
+                                   sizeof(float)*cell_count, nullptr, nullptr);
+    d_pressure = clCreateBuffer(context, CL_MEM_READ_WRITE,
+                                 sizeof(float)*cell_count, nullptr, nullptr);
+    upload();
+
+    std::ifstream file("kernels/weather_kernels.cl");
+    std::string source((std::istreambuf_iterator<char>(file)),
+                       std::istreambuf_iterator<char>());
+    if (!build_kernels(source)) return false;
+    return true;
+}
+
+bool OpenCLWeatherSim::init_opencl() {
+    cl_uint num;
+    clGetPlatformIDs(1, &platform, &num);
+    if (!num) return false;
+    clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, &num);
+    if (!num) return false;
+    context = clCreateContext(nullptr, 1, &device, nullptr, nullptr, nullptr);
+    queue = clCreateCommandQueueWithProperties(context, device, nullptr, nullptr);
+    return true;
+}
+
+bool OpenCLWeatherSim::build_kernels(const std::string& source) {
+    const char* src = source.c_str();
+    size_t len = source.size();
+    program = clCreateProgramWithSource(context, 1, &src, &len, nullptr);
+    if (!program) return false;
+    if (clBuildProgram(program, 1, &device, nullptr, nullptr, nullptr) != CL_SUCCESS) {
+        size_t log_size;
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, nullptr, &log_size);
+        std::string log(log_size, '\0');
+        clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log.data(), nullptr);
+        std::cerr << "Kernel build error:\n" << log << std::endl;
+        return false;
+    }
+    update_kernel = clCreateKernel(program, "update_fields", nullptr);
+    return update_kernel != nullptr;
+}
+
+void OpenCLWeatherSim::upload() {
+    clEnqueueWriteBuffer(queue, d_temperature, CL_TRUE, 0,
+                         sizeof(float)*cell_count, h_temperature.data(), 0, nullptr, nullptr);
+    clEnqueueWriteBuffer(queue, d_pressure, CL_TRUE, 0,
+                         sizeof(float)*cell_count, h_pressure.data(), 0, nullptr, nullptr);
+}
+
+void OpenCLWeatherSim::download() {
+    clEnqueueReadBuffer(queue, d_temperature, CL_TRUE, 0,
+                        sizeof(float)*cell_count, h_temperature.data(), 0, nullptr, nullptr);
+    clEnqueueReadBuffer(queue, d_pressure, CL_TRUE, 0,
+                        sizeof(float)*cell_count, h_pressure.data(), 0, nullptr, nullptr);
+}
+
+void OpenCLWeatherSim::step() {
+    size_t global[3] = {grid.nx, grid.ny, grid.nz};
+    clSetKernelArg(update_kernel, 0, sizeof(cl_mem), &d_temperature);
+    clSetKernelArg(update_kernel, 1, sizeof(cl_mem), &d_pressure);
+    clSetKernelArg(update_kernel, 2, sizeof(int), &grid.nx);
+    clSetKernelArg(update_kernel, 3, sizeof(int), &grid.ny);
+    clSetKernelArg(update_kernel, 4, sizeof(int), &grid.nz);
+    clEnqueueNDRangeKernel(queue, update_kernel, 3, nullptr, global, nullptr, 0, nullptr, nullptr);
+    clFinish(queue);
+    download();
+}


### PR DESCRIPTION
## Summary
- integrate `OpenCLWeatherSim` into `AtmosphericLBM`
- expose GPU option via constructor
- update executables and tests for the new API
- add `HAVE_OPENCL` definition in CMake

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_68899179874c8321bd464937208a0f56