### PR TITLE
Fix CI by installing OpenCL dev packages

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -54,9 +54,13 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Update package lists
+      if: runner.os == 'Linux'
+      run: sudo apt-get update
+
     - name: Install dependencies
       if: runner.os == 'Linux'
-      run: sudo apt-get update && sudo apt-get install -y ocl-icd-opencl-dev opencl-headers
+      run: sudo apt-get install -y ocl-icd-opencl-dev opencl-headers
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -54,6 +54,10 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Install dependencies
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y ocl-icd-opencl-dev opencl-headers
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type


### PR DESCRIPTION
## Summary
- install OpenCL headers in CI workflow

## Testing
- `cmake -B build -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_BUILD_TYPE=Release -S .`
- `cmake --build build --config Release`
- `ctest --build-config Release`

------
https://chatgpt.com/codex/tasks/task_e_688bd9b0cb8c8321ae2ccc6f2081cf37